### PR TITLE
Implement request IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # mock-raf
 
-A simple mock for `requestAnimationFrame` testing with fake timers.
-
-Adapted with gratitude from [`react-motion`](https://github.com/chenglou/react-motion/blob/dafff3f2b00ac11f39d91f3363cc97de664b2406/test/createMockRaf.js). Original source [here](https://github.com/chenglou/react-motion/blob/dafff3f2b00ac11f39d91f3363cc97de664b2406/test/createMockRaf.js). 
+A simple mock for `requestAnimationFrame` testing with fake timers. This is a fork of the
+ mock-raf package provided by [Alex Lande](https://github.com/alexlande) which can be found
+ [`here`](https://github.com/FormidableLabs/mock-raf). This fork implements request IDs, which
+ can be used e.g. to test if the right animation frames are cancelled.
 
 ## Basic Usage
 
@@ -40,11 +41,16 @@ Returns the current `now` value of the mock. Starts at 0 and increases with each
 
 ### `raf()`
 
-Replacement for `requestAnimationFrame` or a polyfill. Adds a callback to be fired on the next step.
+Replacement for `requestAnimationFrame` or a polyfill. Adds a callback to be fired on the next step
+and returns an `id` which may be used with `cancel()`.
 
-### `cancel()`
+### `cancel([id])`
 
-Replacement for `cancelAnimationFrame` or a polyfill. Removes all currently scheduled `requestAnimationFrame` callbacks from the queue.
+Replacement for `cancelAnimationFrame` or a polyfill. If provided with an `id`, it removes the
+`requestAnimationFrame` callback associated with this `id` if it exists.
+
+If no argument is provided,
+all queued `requestAnimationFrame` callbacks are removed.
 
 ### `step(options)`
 

--- a/index.js
+++ b/index.js
@@ -29,16 +29,16 @@ module.exports = function () {
     }, opts);
 
     if (options.count > 0) {
-      callAllCallbacks();
-      allCallbacks = {};
+      callAndRemoveAllCallbacks();
       prevTime += options.time * options.count;
     }
   };
 
-  var callAllCallbacks = function () {
+  var callAndRemoveAllCallbacks = function () {
     for (var id in allCallbacks) {
       if (allCallbacks.hasOwnProperty(id)) {
         allCallbacks[id]();
+        delete allCallbacks[id];
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -1,19 +1,25 @@
 var assign = require('object-assign');
 
 module.exports = function () {
-  var allCallbacks = [];
+  var allCallbacks = {};
   var prevTime = 0;
+  var nextCallbackID = 0;
 
   var now = function () {
     return prevTime;
   };
 
   var raf = function (callback) {
-    allCallbacks.push(callback);
+    allCallbacks[nextCallbackID] = callback;
+    return nextCallbackID++;
   };
 
-  var cancel = function () {
-    allCallbacks = [];
+  var cancel = function (callbackID) {
+    if (typeof callbackID === 'number') {
+      delete allCallbacks[callbackID];
+    } else {
+      allCallbacks = {};
+    }
   };
 
   var step = function (opts) {
@@ -22,19 +28,20 @@ module.exports = function () {
       count: 1
     }, opts);
 
-    var oldAllCallbacks;
-
-    for (var i = 0; i < options.count; i++) {
-      oldAllCallbacks = allCallbacks;
-      allCallbacks = [];
-
-      oldAllCallbacks.forEach(function (callback) {
-        callback();
-      });
-
-      prevTime += options.time;
+    if (options.count > 0) {
+      callAllCallbacks();
+      allCallbacks = {};
+      prevTime += options.time * options.count;
     }
-  }
+  };
+
+  var callAllCallbacks = function () {
+    for (var id in allCallbacks) {
+      if (allCallbacks.hasOwnProperty(id)) {
+        allCallbacks[id]();
+      }
+    }
+  };
 
   return {
     now: now,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mock-raf",
-  "version": "0.0.2",
-  "description": "A simple mock for requestAnimationFrame testing with fake timers.",
+  "name": "mockraf",
+  "version": "0.1.0",
+  "description": "A simple mock for requestAnimationFrame testing with fake timers and request IDs.",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/FormidableLabs/mock-raf.git"
+    "url": "https://github.com/lukastaegert/mock-raf.git"
   },
   "devDependencies": {
     "mocha": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockraf",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A simple mock for requestAnimationFrame testing with fake timers and request IDs.",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/FormidableLabs/mock-raf.git"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -68,4 +68,16 @@ describe('mock-raf', function () {
     });
     assert(callback.calledOnce);
   });
+
+  it('should only remove callbacks which have been called', function () {
+    var callback2 = sinon.stub();
+    var callback1 = function() {
+      mockRaf.raf(callback2);
+    };
+    mockRaf.raf(callback1);
+    mockRaf.step();
+    assert(callback2.notCalled);
+    mockRaf.step();
+    assert(callback2.called);
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,71 @@
+var createMockRaf = require('../index');
+var mockRaf = createMockRaf();
+
+var assert = require('assert');
+var sinon = require('sinon');
+
+describe('mock-raf', function () {
+  it('should call all callbacks when calling step', function () {
+    var callback1 = sinon.stub();
+    var callback2 = sinon.stub();
+    mockRaf.raf(callback1);
+    mockRaf.raf(callback2);
+    mockRaf.step();
+    assert(callback1.called);
+    assert(callback2.called);
+  });
+
+  it('should remove the callbacks once they have been called', function () {
+    var callback = sinon.stub();
+    mockRaf.raf(callback);
+    mockRaf.step();
+    callback.reset();
+    mockRaf.step();
+    assert(callback.notCalled);
+  });
+
+  it('should remove all callbacks when calling cancel without arguments', function () {
+    var callback = sinon.stub();
+    mockRaf.raf(callback);
+    mockRaf.cancel();
+    mockRaf.step();
+    assert(callback.notCalled);
+  });
+
+  it('should only remove the specified callback when calling cancel with a callback ID', function () {
+    const callback1 = sinon.stub();
+    const callback2 = sinon.stub();
+    var id1 = mockRaf.raf(callback1);
+    mockRaf.raf(callback2);
+    mockRaf.cancel(id1);
+    mockRaf.step();
+    assert(callback1.notCalled);
+    assert(callback2.called);
+  });
+
+  it('should advance the mocked time coordinate when calling step', function () {
+    var initialTime = mockRaf.now();
+    mockRaf.step({
+      time: 1
+    });
+    assert.equal(initialTime + 1, mockRaf.now());
+  });
+
+  it('should properly advance time for several steps', function () {
+    var initialTime = mockRaf.now();
+    mockRaf.step({
+      time: 1,
+      count: 2
+    });
+    assert.equal(initialTime + 2, mockRaf.now());
+  });
+
+  it('should call the callbacks only once for several steps', function () {
+    var callback = sinon.stub();
+    mockRaf.raf(callback);
+    mockRaf.step({
+      count: 2
+    });
+    assert(callback.calledOnce);
+  });
+});


### PR DESCRIPTION
When using this really helpful mock library, I came about an issue where I wanted to check if animation frames were properly cancelled by our app. Since cancelling currently means for mock-raf that ALL callbacks are removed, not only the ones specified via an ID, this was not possible.

I have implemented a possible change, along with a simple mocha test, that would implement this functionality without breaking backwards compatibility (hopefully).
