### PR TITLE
Should pass in timestamp to render callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function () {
       allCallbacks = [];
 
       oldAllCallbacks.forEach(function (callback) {
-        callback();
+        callback(prevTime);
       });
 
       prevTime += options.time;

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function () {
       allCallbacks = [];
 
       oldAllCallbacks.forEach(function (callback) {
-        callback(prevTime);
+        callback(prevTime + options.time);
       });
 
       prevTime += options.time;


### PR DESCRIPTION
This is standard behavior. It's often relied on to calculate variables used in the rendering.
